### PR TITLE
Added refresh to fix problem with entity relation dependencies

### DIFF
--- a/DataFixtures/ArrayFixturesLoader.php
+++ b/DataFixtures/ArrayFixturesLoader.php
@@ -75,6 +75,8 @@ class ArrayFixturesLoader implements ContainerAwareInterface
             }
 
             $manager->persist($object);
+            $manager->flush();
+
             $this->referenceRepository->addReference($referenceName, $object);
 
             if ($postPersist !== null) {

--- a/DataFixtures/ArrayFixturesLoader.php
+++ b/DataFixtures/ArrayFixturesLoader.php
@@ -76,6 +76,7 @@ class ArrayFixturesLoader implements ContainerAwareInterface
 
             $manager->persist($object);
             $manager->flush();
+            $manager->refresh($object);
 
             $this->referenceRepository->addReference($referenceName, $object);
 

--- a/Tests/DataFixtures/ArrayFixturesLoaderTest.php
+++ b/Tests/DataFixtures/ArrayFixturesLoaderTest.php
@@ -52,15 +52,18 @@ class ArrayFixturesLoaderTest extends \PHPUnit_Framework_TestCase
                 'example.object.0' => array(
                     'publicProperty' => 'value1',
                     'privatePropertyWithSetMethod' => 'value2',
+                    'privateSelfReferenceParentProperty' => null
                 ),
                 'example.object.1' => array(
                     'publicProperty' => 'value4',
                     'privatePropertyWithSetMethod' => 'value5',
+                    'privateSelfReferenceParentProperty' => '@example.object.0'
                 )
             )
         );
         $this->loader->load($fixture, $this->manager);
 
+        /** @var $objects ExampleObject[] */
         $objects = $this->manager->all();
 
         $this->assertCount(count($fixture['data']), $objects);
@@ -72,7 +75,15 @@ class ArrayFixturesLoaderTest extends \PHPUnit_Framework_TestCase
             $this->assertInstanceOf($fixture['class'], $object);
             $this->assertEquals($value['publicProperty'], $object->publicProperty);
             $this->assertEquals($value['privatePropertyWithSetMethod'], $object->getPrivatePropertyWithSetMethod());
+
+            $selfParent = $value['privateSelfReferenceParentProperty'];
+            if ($selfParent !== null) {
+                $selfParent = $objects[ltrim($selfParent, '@')];
+            }
+            $this->assertEquals($selfParent, $object->getPrivateSelfReferenceParentProperty());
         }
+
+        $this->assertEquals($objects['example.object.1'], $objects['example.object.0']->getPrivateSelfReferenceChildrenProperty());
     }
 
     /**

--- a/Tests/Fixtures/DataTransformer/ExampleObject.php
+++ b/Tests/Fixtures/DataTransformer/ExampleObject.php
@@ -13,6 +13,16 @@ class ExampleObject
 
     private $privatePropertyWithAddMethod;
 
+    /**
+     * @var ExampleObject
+     */
+    private $privateSelfReferenceParentProperty;
+
+    /**
+     * @var ExampleObject[]
+     */
+    private $privateSelfReferenceChildrenProperty;
+
     public function getId()
     {
         return $this->id;
@@ -41,5 +51,37 @@ class ExampleObject
     protected function getPrivateProperty()
     {
         return $this->privateProperty;
+    }
+
+    /**
+     * @return ExampleObject[]
+     */
+    public function getPrivateSelfReferenceChildrenProperty()
+    {
+        return $this->privateSelfReferenceChildrenProperty;
+    }
+
+    /**
+     * @param ExampleObject[] $privateSelfReferenceChildrenProperty
+     */
+    public function setPrivateSelfReferenceChildrenProperty($privateSelfReferenceChildrenProperty)
+    {
+        $this->privateSelfReferenceChildrenProperty = $privateSelfReferenceChildrenProperty;
+    }
+
+    /**
+     * @return ExampleObject
+     */
+    public function getPrivateSelfReferenceParentProperty()
+    {
+        return $this->privateSelfReferenceParentProperty;
+    }
+
+    /**
+     * @param ExampleObject $privateSelfReferenceParentProperty
+     */
+    public function setPrivateSelfReferenceParentProperty($privateSelfReferenceParentProperty)
+    {
+        $this->privateSelfReferenceParentProperty = $privateSelfReferenceParentProperty;
     }
 }


### PR DESCRIPTION
I've got a problem with entity relations. When one entity depends on some collection of other entity, then this collection is not refreshed with newly added entities.

Example:
We have 3 entities:
* User (items)
* Item (price, user)
* Payment (total_price, user)

1. We create user with no items.
2. We create few items with reference to user.
3. We create new payment with reference to user. When user is set, total_price is calculated, but the problem is that User was not refreshed and User object has empty collection at this point.

Refresh fixed this problem for me. I am not sure how to test this properly though. `InMemoryObjectManager` does nothing on refresh and keeps everything in memory and I don't want to add external requirements to run tests.

Any ideas? Maybe there are other solutions how to solve this.