### PR TITLE
Added property transformer

### DIFF
--- a/DataFixtures/ArrayFixturesLoader.php
+++ b/DataFixtures/ArrayFixturesLoader.php
@@ -49,6 +49,15 @@ class ArrayFixturesLoader implements ContainerAwareInterface
                 new $fixture['transformer']()
             ;
         }
+        $propertyTransformers = [];
+        if (!empty($fixture['propertyTransformer'])) {
+            foreach ($fixture['propertyTransformer'] as $property => $definition) {
+                $propertyTransformers[$property] = $definition{0} == '@' ?
+                    $this->container->get(substr($definition, 1)) :
+                    new $definition()
+                ;
+            }
+        }
         $transformer = isset($transformer) ?
             $transformer :
             $this->container->get('pecserke_fixtures.object_transformer')
@@ -63,7 +72,7 @@ class ArrayFixturesLoader implements ContainerAwareInterface
             $postPersist = isset($data[self::POST_PERSIST_ANNOTATION]) ? $data[self::POST_PERSIST_ANNOTATION] : null;
             unset($data[self::POST_PERSIST_ANNOTATION]);
 
-            $data = $this->parse($data);
+            $data = $this->parse($data, $propertyTransformers);
             $object = $transformer->transform($data, $fixture['class']);
 
             if (!empty($fixture['equal_condition'])) {
@@ -88,7 +97,7 @@ class ArrayFixturesLoader implements ContainerAwareInterface
                     ));
 
                 }
-                $postPersist = $this->parse($postPersist);
+                $postPersist = $this->parse($postPersist, $propertyTransformers);
                 if (!is_object($postPersist[0])) {
                     throw new \InvalidArgumentException(sprintf(
                         'invalid postPersist callback at "%s": argument 1: object expected, %s given',
@@ -113,7 +122,12 @@ class ArrayFixturesLoader implements ContainerAwareInterface
         $manager->flush();
     }
 
-    protected function parse(array $array)
+    /**
+     * @param mixed $array
+     * @param DataTransformerInterface[] $propertyTransformers
+     * @return mixed
+     */
+    protected function parse(array $array, array $propertyTransformers)
     {
         $dataTransformer = !empty($array[self::DATA_TRANSFORMER_ANNOTATION]) ? $array[self::DATA_TRANSFORMER_ANNOTATION] : null;
         unset($array[self::DATA_TRANSFORMER_ANNOTATION]);
@@ -142,7 +156,11 @@ class ArrayFixturesLoader implements ContainerAwareInterface
                         break;
                 }
             } else if (is_array($value)) {
-                $array[$key] = $this->parse($value);
+                $array[$key] = $this->parse($value, $propertyTransformers);
+            }
+
+            if (!empty($propertyTransformers[$key])) {
+                $array[$key] = $propertyTransformers[$key]->transform($array[$key]);
             }
         }
 


### PR DESCRIPTION
@tomas-pecserke I've added propretyTransformer, with this it's possible to easily add transformer for property.

Example:

``` yaml
Acme\AcmeBundle\Entity\Person:
    propertyTransformer:
        birthDate: Acme\AcmeBundle\DateTransformer
    data:
        john_doe:
            name: John Doe
            birthDate: 2014-07-12
```

``` php
namespace Acme\AcmeBundle;

use Pecserke\YamlFixturesBundle\DataTransformer\DataTransformerInterface;

class DateTransformer implements DataTransformerInterface
{
    public function transform($data)
    {
        $dateTime = new \DateTime($data);
        $dateTime->setTime(0, 0, 0);

        return $dateTime;
    }
}
```

Let me know what do you think. If it's ok, then I can add documentation, tests and refactor it a little bit.
