### PR TITLE
Empty file exception

### DIFF
--- a/DataFixtures/Exception/ConfigurationNotFoundException.php
+++ b/DataFixtures/Exception/ConfigurationNotFoundException.php
@@ -1,6 +1,0 @@
-<?php
-namespace Pecserke\YamlFixturesBundle\DataFixtures\Exception;
-
-class ConfigurationNotFoundException extends \InvalidArgumentException
-{
-}

--- a/DataFixtures/Exception/ConfigurationNotFoundException.php
+++ b/DataFixtures/Exception/ConfigurationNotFoundException.php
@@ -1,0 +1,6 @@
+<?php
+namespace Pecserke\YamlFixturesBundle\DataFixtures\Exception;
+
+class ConfigurationNotFoundException extends \InvalidArgumentException
+{
+}

--- a/DataFixtures/Exception/InvalidFixturesException.php
+++ b/DataFixtures/Exception/InvalidFixturesException.php
@@ -1,0 +1,24 @@
+<?php
+namespace Pecserke\YamlFixturesBundle\DataFixtures\Exception;
+
+class InvalidFixturesException extends \InvalidArgumentException
+{
+    /**
+     * @param string $file
+     * @return InvalidFixturesException
+     */
+    static public function emptyData($file)
+    {
+        return new InvalidFixturesException("no fixture configuration found in file '$file', fix this by adding fixture configuration to file or by removing the file");
+    }
+
+    /**
+     * @param string $file
+     * @param mixed $fixtures
+     * @return InvalidFixturesException
+     */
+    static public function mustBeArray($file, $fixtures)
+    {
+        return new InvalidFixturesException("fixtures in file '$file', must be defined as array. Data given: " . print_r($fixtures, true));
+    }
+}

--- a/DataFixtures/YamlFixtureFileParser.php
+++ b/DataFixtures/YamlFixtureFileParser.php
@@ -1,6 +1,7 @@
 <?php
 namespace Pecserke\YamlFixturesBundle\DataFixtures;
 
+use Pecserke\YamlFixturesBundle\DataFixtures\Exception\ConfigurationNotFoundException;
 use Symfony\Component\Yaml\Yaml;
 
 /**
@@ -13,6 +14,7 @@ class YamlFixtureFileParser
      *
      * @param array $fixtureFiles
      * @throws \InvalidArgumentException
+     * @throws ConfigurationNotFoundException
      * @return array
      */
     public function parse(array $fixtureFiles)
@@ -26,6 +28,9 @@ class YamlFixtureFileParser
         $unsorted = array();
 
         foreach ($fixturesData as $file => $fixtures) {
+            if (empty($fixtures)) {
+                throw new ConfigurationNotFoundException("no fixture configuration found in file '$file', fix this by adding fixture configuration to file or by removing the file");
+            }
             foreach ($fixtures as $class => $fixture) {
                 if (!class_exists($class)) {
                     throw new \InvalidArgumentException("class '$class' doesn't exist in file '$file'");

--- a/DataFixtures/YamlFixtureFileParser.php
+++ b/DataFixtures/YamlFixtureFileParser.php
@@ -1,7 +1,7 @@
 <?php
 namespace Pecserke\YamlFixturesBundle\DataFixtures;
 
-use Pecserke\YamlFixturesBundle\DataFixtures\Exception\ConfigurationNotFoundException;
+use Pecserke\YamlFixturesBundle\DataFixtures\Exception\InvalidFixturesException;
 use Symfony\Component\Yaml\Yaml;
 
 /**
@@ -14,7 +14,7 @@ class YamlFixtureFileParser
      *
      * @param array $fixtureFiles
      * @throws \InvalidArgumentException
-     * @throws ConfigurationNotFoundException
+     * @throws InvalidFixturesException
      * @return array
      */
     public function parse(array $fixtureFiles)
@@ -29,7 +29,10 @@ class YamlFixtureFileParser
 
         foreach ($fixturesData as $file => $fixtures) {
             if (empty($fixtures)) {
-                throw new ConfigurationNotFoundException("no fixture configuration found in file '$file', fix this by adding fixture configuration to file or by removing the file");
+                throw InvalidFixturesException::emptyData($file);
+            }
+            if (!is_array($fixtures)) {
+                throw InvalidFixturesException::mustBeArray($file, $fixtures);
             }
             foreach ($fixtures as $class => $fixture) {
                 if (!class_exists($class)) {

--- a/Tests/DataFixtures/YamlFixtureFileParserTest.php
+++ b/Tests/DataFixtures/YamlFixtureFileParserTest.php
@@ -11,6 +11,6 @@ class YamlFixtureFileParserTest extends \PHPUnit_Framework_TestCase
     public function testParseThrowsConfigurationNotFundExceptionIfYamlFileIsEmpty()
     {
         $parser = new YamlFixtureFileParser();
-        $parser->parse(['']);
+        $parser->parse(array(''));
     }
 }

--- a/Tests/DataFixtures/YamlFixtureFileParserTest.php
+++ b/Tests/DataFixtures/YamlFixtureFileParserTest.php
@@ -1,0 +1,16 @@
+<?php
+namespace Pecserke\YamlFixturesBundle\Tests\DataFixtures;
+
+use Pecserke\YamlFixturesBundle\DataFixtures\YamlFixtureFileParser;
+
+class YamlFixtureFileParserTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @expectedException \Pecserke\YamlFixturesBundle\DataFixtures\Exception\ConfigurationNotFoundException
+     */
+    public function testParseThrowsConfigurationNotFundExceptionIfYamlFileIsEmpty()
+    {
+        $parser = new YamlFixtureFileParser();
+        $parser->parse(['']);
+    }
+}

--- a/Tests/DataFixtures/YamlFixtureFileParserTest.php
+++ b/Tests/DataFixtures/YamlFixtureFileParserTest.php
@@ -11,7 +11,7 @@ class YamlFixtureFileParserTest extends \PHPUnit_Framework_TestCase
     public function testParseThrowsInvalidFixturesOnEmptyData()
     {
         $parser = new YamlFixtureFileParser();
-        $parser->parse(null);
+        $parser->parse([]);
     }
 
     /**
@@ -20,6 +20,8 @@ class YamlFixtureFileParserTest extends \PHPUnit_Framework_TestCase
     public function testParseThrowsInvalidFixturesOnNotArrayFixtures()
     {
         $parser = new YamlFixtureFileParser();
-        $parser->parse('test');
+        $parser->parse([
+            ['file' => 'incorrect_data']
+        ]);
     }
 }

--- a/Tests/DataFixtures/YamlFixtureFileParserTest.php
+++ b/Tests/DataFixtures/YamlFixtureFileParserTest.php
@@ -6,11 +6,20 @@ use Pecserke\YamlFixturesBundle\DataFixtures\YamlFixtureFileParser;
 class YamlFixtureFileParserTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @expectedException \Pecserke\YamlFixturesBundle\DataFixtures\Exception\ConfigurationNotFoundException
+     * @expectedException \Pecserke\YamlFixturesBundle\DataFixtures\Exception\InvalidFixturesException
      */
-    public function testParseThrowsConfigurationNotFundExceptionIfYamlFileIsEmpty()
+    public function testParseThrowsInvalidFixturesOnEmptyData()
     {
         $parser = new YamlFixtureFileParser();
-        $parser->parse(array(''));
+        $parser->parse(null);
+    }
+
+    /**
+     * @expectedException \Pecserke\YamlFixturesBundle\DataFixtures\Exception\InvalidFixturesException
+     */
+    public function testParseThrowsInvalidFixturesOnNotArrayFixtures()
+    {
+        $parser = new YamlFixtureFileParser();
+        $parser->parse('test');
     }
 }


### PR DESCRIPTION
When a left over yaml fixture file with no content was loaded, then error foreach can't iterate was triggered.

I've added exception for this case with message to explain what is wrong :-)