### PR TITLE
Flush only at the end of Array fixtures load

### DIFF
--- a/DataFixtures/ArrayFixturesLoader.php
+++ b/DataFixtures/ArrayFixturesLoader.php
@@ -75,8 +75,6 @@ class ArrayFixturesLoader implements ContainerAwareInterface
             }
 
             $manager->persist($object);
-            $manager->flush();
-
             $this->referenceRepository->addReference($referenceName, $object);
 
             if ($postPersist !== null) {


### PR DESCRIPTION
This change improved Fixtures load speed from 28 seconds to 6.5 seconds with my dataset.

I didn't find any issues so far. Is there a special reason why we have to flush more often?