### PR TITLE
Don't use ignore-platform-reqs when installing mongo-php-adapter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,8 @@ cache:
         - vendor
 
 before_install:
-    - if [[ $TRAVIS_PHP_VERSION = 5.* ]]; then echo "extension=mongo.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; else COMPOSER_FLAGS="$COMPOSER_FLAGS --ignore-platform-reqs"; fi
-    - if [[ $TRAVIS_PHP_VERSION = 5.* ]]; then composer remove --dev alcaeus/mongo-php-adapter --no-update; fi
+    - if [[ $TRAVIS_PHP_VERSION = 5.* ]]; then echo "extension=mongo.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
+    - if [[ $TRAVIS_PHP_VERSION = 7.* ]]; then composer config "platform.ext-mongo" "1.6.16" && composer require alcaeus/mongo-php-adapter --no-update; fi
     - composer self-update
     - if [[ "$SYMFONY_VERSION" != "" ]]; then composer require "symfony/framework-bundle:${SYMFONY_VERSION}" --no-update; fi
 

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,6 @@
         "doctrine/orm": ">=2.2",
         "doctrine/mongodb-odm": "~1.0",
         "phpunit/phpunit": ">=4.3",
-        "alcaeus/mongo-php-adapter": "^1.0.3",
         "satooshi/php-coveralls": "~1.0",
         "mikey179/vfsStream": "~1.0"
     },


### PR DESCRIPTION
Using `ignore-platform-reqs` can cause a bunch of errors down the line (e.g. by installing incompatible package versions not suited for the current PHP version). Thus, `ext-mongodb` is provided via `config.platform`.

In this case, I also removed mongo-php-adapter from composer.json to avoid having to provide a blanket platform config that would hide errors when trying to run on PHP 5.x without `ext-mongo` installed.